### PR TITLE
Convenience method for setting bit_fields using symbols on column_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,39 @@ class User < Sequel::Model
 end
 ```
 
+### Assigning symbols to columns and multiple bit_field assignment
+
+You may want to set a bit_field via the column name and pass it a symbol.
+Or you may find it useful to turn on multiple bit_fields at the same time.
+
+Values that are not passed will be set to false. This behavior is useful 
+if you want to set specific bit_fields and not have to set every bit_field.
+
+Given the model:
+```ruby
+class MyModel < Sequel::Model
+  plugin :bit_fields, :roles, [:author,:contributor,:reader]
+end
+```
+
+Let's create a user that is a reader and contributor:
+
+```ruby
+user = MyModel.new
+user.roles = [:contributor,:reader]
+
+user.contributor? # true
+user.reader?      # true
+user.author?      # false
+
+user.roles = :author
+
+user.author?      # true
+user.reader?      # false
+user.contributor? # false
+```
+
+
 ## The table
 
 If you are creating a new model from scratch:
@@ -214,3 +247,4 @@ Hereby released under MIT license.
 - [Sascha Depold](http://depold.com) ([Twitter](http://twitter.com/sdepold) | [Github](http://github.com/sdepold))
 - jethroo
 - [Markus 'iblue' Fenske](http://github.com/iblue)
+- [Jon Pitts](http://github.com/jonpitts)

--- a/spec/sequel/plugins/bit_fields_spec.rb
+++ b/spec/sequel/plugins/bit_fields_spec.rb
@@ -10,6 +10,10 @@ class AnotherSpecModel < Sequel::Model
   plugin :bit_fields, :some_other_bits, [ :fnord ], :scope => true
 end
 
+class SpecRolesModel < Sequel::Model
+  plugin :bit_fields, :roles, [:author, :contributor, :reader]
+end
+
 class NoBitFieldsSpecModel < Sequel::Model
 end
 
@@ -32,7 +36,7 @@ paranoid_bits_result = [{
 describe Sequel::Plugins::BitFields do
   describe :bit_fields_for_models do
     it 'returns all defined bit fields for all models' do
-      Sequel::Plugins::BitFields.bit_fields_for_models.keys.sort.should == ['AnotherSpecModel', 'SpecModel']
+      Sequel::Plugins::BitFields.bit_fields_for_models.keys.sort.should == ['AnotherSpecModel', 'SpecModel', 'SpecRolesModel']
     end
   end
 
@@ -288,7 +292,89 @@ describe Sequel::Plugins::BitFields do
       end
     end
   end
-
+  
+  describe :bit_field_column= do
+    context "an object with roles set to :author" do
+      before do
+        @model = SpecRolesModel.create
+        @model.roles = :author
+      end
+      
+      it "returns true for author?" do
+        @model.author?.should be_true
+      end
+      
+      it "returns false for reader? and contributor?" do
+        @model.reader?.should be_false
+        @model.contributor?.should be_false
+      end
+    end
+    
+    context "an object with roles set to [:reader,:contributor]" do
+      before do
+        @model = SpecRolesModel.create
+        @model.roles = [:reader,:contributor]
+      end
+      
+      it "returns true for reader? and contributor? and returns false for author?" do
+        @model.reader?.should be_true
+        @model.contributor?.should be_true
+        @model.author?.should be_false
+      end
+      
+      it "returns false for reader? and contributor? if roles set to :author" do
+        @model.roles = :author
+        @model.reader?.should be_false
+        @model.contributor?.should be_false
+      end
+      
+      context "an object with roles set to 6" do
+        before do
+          @model = SpecRolesModel.create
+          @model.roles = 6
+        end
+        
+        it "returns true for reader? and contributor? and returns false for author?" do
+          @model.reader?.should be_true
+          @model.contributor?.should be_true
+          @model.author?.should be_false
+        end
+        
+        it "returns false for author? reader? and contributor? if roles set to 0" do
+          @model.roles = 0
+          @model.reader?.should be_false
+          @model.contributor?.should be_false
+          @model.author?.should be_false
+        end
+        
+        it "returns true for author? and false for reader? and contributor? if roles set to 1" do
+          @model.roles = 1
+          @model.reader?.should be_false
+          @model.contributor?.should be_false
+          @model.author?.should be_true
+        end
+      end
+      
+      context "an object with roles set to []" do
+        before do
+          @model = SpecRolesModel.create
+          @model.roles = []
+        end
+        
+        it "returns false for author? reader? and contributor?" do
+          @model.reader?.should be_false
+          @model.contributor?.should be_false
+          @model.author?.should be_false
+        end
+        
+        it "returns true for author? if roles set to [:author]" do
+          @model.roles = [:author]
+          @model.author?.should be_true
+        end
+      end
+    end
+  end
+  
   describe :bit_field_values_for do
     context "an object with finished set to true" do
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,11 @@ RSpec.configure do |config|
     primary_key :id, :auto_increment => true
     Bignum :some_bits, :null => false, :default => 0
   end
+  
+  DB.create_table(:spec_roles_models) do
+    primary_key :id, :auto_increment => true
+    Bignum :roles, :null => false, :default => 0
+  end
 
   DB.create_table(:no_bit_fields_spec_models) do
     primary_key :id, :auto_increment => true


### PR DESCRIPTION
I've been messing around with migrating some models from DataMapper over to Sequel.  Sequel-bit_fields has been super helpful.  

My suggested change more or less adds a similar behavior from the Flag type found in dm-types.  This allows assigning bit_fields by passing symbols into the model's associated column_name/property.  Let me know what you think.
