### PR TITLE
Bugfix: uninitialized constant Sequel::Plugins::BitFields::DB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :development, :test do
   gem "bundler", ">= 1.0.0"
   gem "rspec", "~> 2"
   gem "sqlite3"
-  gem "pg"
   gem 'watchr'
   gem 'rake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
-    pg (0.17.1)
     rake (0.9.2.2)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
@@ -21,7 +20,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.0.0)
-  pg
   rake
   rspec (~> 2)
   sequel (~> 3.34)

--- a/lib/sequel/plugins/bit_fields.rb
+++ b/lib/sequel/plugins/bit_fields.rb
@@ -133,7 +133,7 @@ module Sequel::Plugins
             value   = true if value.nil?
             options = { :table => self.table_name.to_s }.merge([*args][1] || {})
 
-            "#{DB.literal(Sequel.qualify(options[:table], bit_field_column))} & #{index} #{'!' unless value}= #{index}"
+            "#{db.literal(Sequel.qualify(options[:table], bit_field_column))} & #{index} #{'!' unless value}= #{index}"
           end
         end
 

--- a/spec/sequel/plugins/bit_fields_spec.rb
+++ b/spec/sequel/plugins/bit_fields_spec.rb
@@ -240,11 +240,6 @@ describe Sequel::Plugins::BitFields do
     it "uses the passed table name" do
       SpecModel.reviewed_sql(false, :table => '_spec_models').should == "`_spec_models`.`status_bits` & 4 != 4"
     end
-
-    it "properly quotes table and column when using postgres" do
-      stub_const("DB", Sequel.postgres)
-      SpecModel.started_sql.should == "\"spec_models\".\"status_bits\" & 1 = 1"
-    end
   end
 
   describe :field_dataset do


### PR DESCRIPTION
`DB` is defined by the test suite and breaks the feature in the real world (`uninitialized constant Sequel::Plugins::BitFields::DB`). Since the spec only tested `Sequel`s abilities to properly escape things in postgres, I removed the spec. This should be done in the main sequel test suite.