### PR TITLE
Fix readme to account for Bignum deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ DB.create_table(:my_models) do
 
   # let's use Bignum as it has more space :)
   # set the default to 0 and disallow null values
-  Bignum :status_bits, :null => false, :default => 0
+  add_column :status_bits, :Bignum, :null => false, :default => 0
 end
 ```
 
@@ -232,7 +232,7 @@ If you want to extend an existing model:
 Sequel.migration do
   change do
     alter_table :users do
-      add_column :permission_bits, Bignum, :default => 0, :null => false
+      add_column :permission_bits, :Bignum, :default => 0, :null => false
     end
   end
 end


### PR DESCRIPTION
`Bignum` has been deprecated in Ruby as it was merged along with `Fixnum` into `Integer`.  As outlined by [this sequel release note](http://sequel.jeremyevans.net/rdoc/files/doc/release_notes/4_35_0_txt.html), you *can* still use `Bignum` in older Ruby versions without error or behavior change, but the ideal thing to do going forward is to instead use `:Bignum` as a symbol. This updates the instructions to reflect that.